### PR TITLE
Fix the typescript bindings in dungoneer.d.ts

### DIFF
--- a/lib/dungeoneer.d.ts
+++ b/lib/dungeoneer.d.ts
@@ -1,5 +1,5 @@
-declare module 'dungeoneer' {
-  type Tile = {
+declare module "dungeoneer" {
+  type PlainTile = {
     // An object containing the tiles immediately surrounding this tile.
     nesw: {
       n?: Tile;
@@ -15,27 +15,41 @@ declare module 'dungeoneer' {
     y: number;
 
     // 'floor' and 'door' are passable terrain and a wall is impassable terrain.
-    type: 'wall' | 'floor' | 'door';
+    type: "wall" | "floor" | "door";
+  };
+
+  interface Tile extends PlainTile {
+    toJS(): PlainTile;
   }
 
-  type Room = {
+  type PlainRoom = {
     height: number;
     width: number;
     x: number;
     y: number;
+  };
+
+  interface Room extends PlainRoom {
+    getBoundingBox(): {
+      top: number;
+      right: number;
+      bottom: number;
+      left: number;
+    };
+    containsTile(x: number, y: number): boolean;
+    toJS(): PlainRoom;
+    intersects(other: Room): boolean;
   }
 
   type Dungeon = {
     rooms: Room[];
     tiles: Array<Tile[]>;
     seed: string | number;
-  }
+  };
 
-  function build = (options: {
+  function build(options: {
     width: number;
     height: number;
     seed?: string | number;
   }): Dungeon;
-
-  export = build;
 }


### PR DESCRIPTION
Thanks so much for dungoneer / dungeon-factory - I've had great use out of it while putting together https://dungeon-dash.surge.sh/

I've just followed the rename today and found that the newly included Typescript typings have a syntax error with Typescript 3. In fixing that, I corrected the typings against what's currently in the JS and included "reader" methods (as I'm using `getBoundingBox` in my game).

Note that the explicit export that I removed from the typings isn't needed, and ends up meaning that the types included (like Room, Tile, etc) can't be referenced in other code.