### PR TITLE
Change: TS tile definition from nesw to neighbours

### DIFF
--- a/lib/dungeoneer.d.ts
+++ b/lib/dungeoneer.d.ts
@@ -1,7 +1,7 @@
 declare module "dungeoneer" {
   type PlainTile = {
     // An object containing the tiles immediately surrounding this tile.
-    nesw: {
+    neighbours: {
       n?: Tile;
       ne?: Tile;
       e?: Tile;


### PR DESCRIPTION
## Description

While this property is of `Tile` in the `d.ts`:

https://github.com/LucianBuzzo/dungeoneer/blob/a5a016b164e0a146869581d55763ee0976769b9c/lib/dungeoneer.d.ts#L4-L13

The contents of `Tile` returned from `build` during an actual run are:

```javascript
{
    type: "wall",
    neighbours: {
        e: { type: "wall", neighbours: { /* ... */ }, x: 1, y: 0 },
        se: { type: "wall", neighbours: { /* ... */ }, x: 1, y: 1, region: 18 },
        s: { type: "wall", neighbours: { /* ... */ }, x: 0, y: 1 }
    },
    x: 0,
    y: 0
}
```

## Environment

Version is `2.1.4`.

## Changes

Updated the definition file, please consider.