### PR TITLE
Fix room height calculation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -367,7 +367,7 @@ const Dungeon = function Dungeon () {
 
       // Restrict the size of rooms relative to the stage size
       width = Math.min(width, stage.width - 4)
-      height = Math.min(width, stage.height - 4)
+      height = Math.min(height, stage.height - 4)
 
       let x = randBetween(0, Math.floor((stage.width - width) / 2)) * 2 + 1
       let y = randBetween(0, Math.floor((stage.height - height) / 2)) * 2 + 1


### PR DESCRIPTION
## Summary
- fix restrictive height calculation when generating rooms

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: nyc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684857800794832a961b7704d01d8e35