### PR TITLE
Fix typo in seeded dungeon test

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -489,7 +489,7 @@ ava('.build() should return a re-usable seed', (test) => {
   test.deepEqual(dungeon1.toJS(), dungeon2.toJS())
 })
 
-ava('.build() seeded dungeons should be consisten', (test) => {
+ava('.build() seeded dungeons should be consistent', (test) => {
   const width = 21
   const height = 21
   const dungeon = dungeoneer.build({


### PR DESCRIPTION
## Summary
- correct `consisten` typo in index test file

## Testing
- `npm test` *(fails: index build should not list southern neighbour)*

------
https://chatgpt.com/codex/tasks/task_e_68485b6c2704832abf927c19e2dd33c2