### PR TITLE
Fix `seed: 0` being ignored in dungeon generation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -211,7 +211,9 @@ const Dungeon = function Dungeon () {
       stage.height += 1
     }
 
-    const seed = stage.seed || `${nameChance.word({ length: 7 })}-${nameChance.word({ length: 7 })}`
+    const seed = stage.seed === undefined || stage.seed === null
+      ? `${nameChance.word({ length: 7 })}-${nameChance.word({ length: 7 })}`
+      : stage.seed
 
     rng = new Chance(seed)
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -519,6 +519,25 @@ ava('.build() should be seedable', (test) => {
   test.deepEqual(dungeon1.toJS(), dungeon2.toJS())
 })
 
+ava('.build() should accept falsy seeds like 0', (test) => {
+  const width = 21
+  const height = 21
+  const dungeon1 = dungeoneer.build({
+    width,
+    height,
+    seed: 0
+  })
+
+  const dungeon2 = dungeoneer.build({
+    width,
+    height,
+    seed: 0
+  })
+
+  test.deepEqual(dungeon1.toJS(), dungeon2.toJS())
+  test.is(dungeon1.seed, 0)
+})
+
 const sizes = [
   [5, 7],
   [7, 7],


### PR DESCRIPTION
## Summary
`build()` currently derives the seed with `stage.seed || randomSeed`, which treats `0` as absent and replaces it with a random value.

This PR:
- switches seed fallback logic to only generate a random seed when `seed` is `null` or `undefined`
- keeps explicit falsy seeds (like `0`) intact
- adds a regression test proving deterministic output for `seed: 0`

## Why
Numeric seeds are part of the public API (`string | number`). `0` should be a valid deterministic seed, not silently replaced.

## Validation
- `npm test --silent` (50 tests passed)
